### PR TITLE
Fix main workflow guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,11 +140,23 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+
+    - name: Detect Dockerfiles
+      id: dockerfiles
+      run: |
+        if [ -f Dockerfile.api ] || [ -f Dockerfile.web ] || [ -f Dockerfile.agents ]; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          echo "No platform Dockerfiles found; skipping Docker image builds for this corpus-only checkout."
+        fi
     
     - name: Set up Docker Buildx
+      if: steps.dockerfiles.outputs.present == 'true'
       uses: docker/setup-buildx-action@v3
     
     - name: Build API image
+      if: steps.dockerfiles.outputs.present == 'true' && hashFiles('Dockerfile.api') != ''
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -155,6 +167,7 @@ jobs:
         cache-to: type=gha,mode=max
     
     - name: Build Web image
+      if: steps.dockerfiles.outputs.present == 'true' && hashFiles('Dockerfile.web') != ''
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -167,6 +180,7 @@ jobs:
         cache-to: type=gha,mode=max
     
     - name: Build Agent image
+      if: steps.dockerfiles.outputs.present == 'true' && hashFiles('Dockerfile.agents') != ''
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,14 @@
+title: Unity Equilibrium Theory (UET)
+description: A research corpus for Unity Equilibrium Theory.
+
+markdown: kramdown
+highlighter: rouge
+
+exclude:
+  - .git
+  - .github
+  - .venv
+  - node_modules
+  - services_and_experiments
+  - target
+  - uet_history


### PR DESCRIPTION
## Summary
- skip Docker image build steps when the corresponding Dockerfiles are not present
- add root GitHub Pages config so Jekyll does not parse raw `uet_history` files

## Why
Main was red after the recovery merge because the push workflow tried to build missing root Dockerfiles and GitHub Pages parsed raw historical markdown with Liquid-looking equation syntax.

## Checks
- `git diff --check`