### PR TITLE
docs: remove empty economics book placeholder

### DIFF
--- a/WORK_LEDGER/2026/2026-07-08.md
+++ b/WORK_LEDGER/2026/2026-07-08.md
@@ -7,9 +7,19 @@ Paths: `uet_history/`, `WORK_LEDGER/2026/2026-07-08.md`
 Work: replace old public `uet_history` structure with a curated public skeleton that reflects the current raw -> digest -> publish workflow.
 Verification: scoped file inventory; raw/media/development folders excluded from public update.
 Public-safety: `partial`
-Commit status: PR planned
-Next action: merge curated skeleton, then promote selected digest/publish content in smaller reviewed batches.
+Commit status: merged in PR #15
+Next action: promote selected digest/publish content in smaller reviewed batches.
 
 Notes:
 - Do not publish `1_raw/`, `_archive/`, `Dev_history/`, nested `1_raw/`, ZIP, video, audio, PDF, or large media assets in this batch.
 - Legacy public paths are retired from `main` as active organization, but remain recoverable through Git history.
+
+## remove empty economics placeholder
+
+Area: `book-writing`
+Paths: `uet_history/3_publish/books/`, `uet_history/PUBLIC_MANIFEST.md`
+Work: remove the empty `origin_of_wealth_and_economics/` placeholder because it implied public content existed when the actual economics drafts are still local and unreviewed.
+Verification: checked local economics draft folder; content exists locally but needs encoding, claim-strength, and source-boundary review before publication.
+Public-safety: `partial`
+Commit status: PR planned
+Next action: create a separate reviewed economics outline PR when a small public-safe draft is ready.

--- a/uet_history/3_publish/books/README.md
+++ b/uet_history/3_publish/books/README.md
@@ -5,6 +5,14 @@ This folder contains public-facing book and long-form narrative scaffolds.
 Current public projects:
 
 - `00_uet_core_theory/` - core UET theory explanation scaffold
-- `origin_of_wealth_and_economics/` - economics and social-systems book scaffold
 
 Draft inputs and raw chapter sources remain local-only until reviewed.
+
+## Not Yet Published Here
+
+Economics and wealth-origin writing exists locally as draft material, but it is
+not exposed in the public tree yet because the current files still need review
+for encoding, claim strength, source boundary, and raw/draft separation.
+
+When that material is ready, promote a small reviewed outline or chapter draft in
+a separate scoped PR instead of creating an empty placeholder folder.

--- a/uet_history/3_publish/books/origin_of_wealth_and_economics/README.md
+++ b/uet_history/3_publish/books/origin_of_wealth_and_economics/README.md
@@ -1,7 +1,0 @@
-# Origin Of Wealth And Economics
-
-Public scaffold for economics, social systems, and wealth-formation writing tied
-to the broader UET history workspace.
-
-This folder is for reviewed outlines and public-safe drafts. Raw input notes stay
-local until promoted through the digest layer.

--- a/uet_history/PUBLIC_MANIFEST.md
+++ b/uet_history/PUBLIC_MANIFEST.md
@@ -16,7 +16,6 @@ that reflects the current local workflow without publishing raw folders.
 | `uet_history/3_publish/README.md` | included | Publish-layer orientation. |
 | `uet_history/3_publish/books/README.md` | included | Book workspace orientation. |
 | `uet_history/3_publish/books/00_uet_core_theory/README.md` | included | Core UET theory book placeholder. |
-| `uet_history/3_publish/books/origin_of_wealth_and_economics/README.md` | included | Economics/book project placeholder. |
 
 ## Excluded From This Public Update
 
@@ -26,6 +25,7 @@ that reflects the current local workflow without publishing raw folders.
 | `uet_history/_archive/` | Local archive and recovery material; not a current public source tree. |
 | `uet_history/Dev_history/` | Contains raw development snapshots, ZIPs, videos, and large historical assets. |
 | nested `1_raw/` folders inside `3_publish/` | Draft input material; not yet reviewed as public-safe. |
+| economics and wealth-origin book drafts | Local drafts exist, but need encoding, claim-strength, source-boundary, and raw/draft review before public promotion. |
 | media/audio/video/PDF/ZIP files | Large or potentially private assets; should be handled by a separate asset plan. |
 
 ## Legacy Paths Retired From Main


### PR DESCRIPTION
## Summary
- remove the empty public origin_of_wealth_and_economics placeholder
- keep the public books tree limited to reviewed scaffolds
- record the economics/wealth-origin draft as excluded local material that still needs encoding, claim, and source-boundary review

## Notes
This does not delete the local draft material. It only prevents GitHub main from showing an empty misleading book folder.

## Test Plan
- checked branch diff scope against origin/main
- checked uet_history/3_publish/books tree only contains 