### PR TITLE
docs: publish economics book outline

### DIFF
--- a/WORK_LEDGER/2026/2026-07-08.md
+++ b/WORK_LEDGER/2026/2026-07-08.md
@@ -23,3 +23,12 @@ Verification: checked local economics draft folder; content exists locally but n
 Public-safety: `partial`
 Commit status: PR planned
 Next action: create a separate reviewed economics outline PR when a small public-safe draft is ready.
+## publish economics book outline
+
+Area: `book-writing`
+Paths: `uet_history/3_publish/books/origin_of_wealth_and_economics/`, `uet_history/3_publish/books/README.md`, `uet_history/PUBLIC_MANIFEST.md`
+Work: add a small public-safe outline for the economics and wealth-origin book track so GitHub readers can see the project direction without exposing raw notes or full unreviewed drafts.
+Verification: derived from local book blueprint structure; kept claims at proposal/framework level and excluded raw/private draft folders.
+Public-safety: `partial`
+Commit status: PR planned
+Next action: review and promote one concrete chapter section only after encoding, source boundary, and claim wording are cleaned up.

--- a/uet_history/3_publish/books/README.md
+++ b/uet_history/3_publish/books/README.md
@@ -1,18 +1,21 @@
-# UET Book Workspace
+﻿# UET Book Workspace
 
 This folder contains public-facing book and long-form narrative scaffolds.
 
 Current public projects:
 
 - `00_uet_core_theory/` - core UET theory explanation scaffold
+- `origin_of_wealth_and_economics/` - public concept outline for the economics
+  and wealth-origin book track
 
 Draft inputs and raw chapter sources remain local-only until reviewed.
 
-## Not Yet Published Here
+## Publication Boundary
 
-Economics and wealth-origin writing exists locally as draft material, but it is
-not exposed in the public tree yet because the current files still need review
-for encoding, claim strength, source boundary, and raw/draft separation.
+The economics and wealth-origin track now has a small public outline so readers
+can understand what the project is about. The full local drafts are still not
+published here because they need review for encoding, claim strength, source
+boundary, and raw/draft separation.
 
-When that material is ready, promote a small reviewed outline or chapter draft in
-a separate scoped PR instead of creating an empty placeholder folder.
+Future additions should promote reviewed chapter sections in small scoped PRs
+instead of dumping raw notes or unreviewed draft folders into the public tree.

--- a/uet_history/3_publish/books/origin_of_wealth_and_economics/README.md
+++ b/uet_history/3_publish/books/origin_of_wealth_and_economics/README.md
@@ -1,0 +1,92 @@
+# The Origin of Wealth and Economics
+
+**Status:** public concept outline
+**Project type:** book / long-form economics narrative
+**Evidence boundary:** UET-framed proposal and synthesis, not a proven economic law
+
+This workspace is the public entry point for an economics book project inside
+the UET history pipeline. It is meant to show the shape of the work without
+publishing raw chat exports, private notes, unreviewed media, or full draft
+files that still need source and claim review.
+
+## Working Thesis
+
+The book explores wealth as a system-level process rather than only a monetary
+quantity. In this framing, wealth is treated as the durable capacity of a
+society to coordinate energy, knowledge, tools, labor, trust, and institutions
+into useful output over time.
+
+The current draft asks:
+
+- What makes value more than price?
+- How do energy, labor, information, and institutions combine into productive
+  capacity?
+- Why do debt, fiat money, resource access, and political power change the
+  visible shape of wealth?
+- Can economics be described with a more explicit systems vocabulary without
+  pretending the model is already externally validated?
+
+## Public Reader Summary
+
+The project is a UET-style economics narrative. It connects economic value to
+energy flow, knowledge accumulation, infrastructure, institutional trust, and
+the ability of a society to reduce waste while increasing useful coordination.
+
+It is not presented here as a finished theory of economics. The public version
+is a map of the argument and a place to develop reviewed sections later.
+
+## Draft Book Structure
+
+The local draft blueprint currently sketches seven major sections:
+
+| Section | Working Focus | Public Status |
+| --- | --- | --- |
+| Introduction | System contradictions and the meaning of real wealth | outline only |
+| 1. Root of Value | Money, resources, knowledge, services, entropy, and productive capacity | outline only |
+| 2. Firewood Economy | Early energy use, logistics, heat, and social organization | outline only |
+| 3. Measurement and Numbers | Geometry, numeric abstraction, zero, and accounting systems | outline only |
+| 4. Calculus and System Measurement | Change, relation, measurement, and classical physics metaphors | outline only |
+| 5. Critique of Mainstream Systems | Gold standard, fiat, debt cycles, externalities, and power concentration | needs careful review |
+| 6. Dynamic Energy Money | Energy-backed accounting, real assets, governance, and policy design | speculative proposal |
+
+## Claim Discipline
+
+The public wording here is intentionally restrained.
+
+- Use `proposal`, `model`, `framework`, `draft`, or `working thesis`.
+- Do not claim that UET has solved economics.
+- Do not claim that a policy design is verified unless a specific source,
+  benchmark, or implementation result supports it.
+- Treat strong terms such as `proved`, `exact`, `solved`, and `validated` as
+  restricted.
+
+## Local Source Boundary
+
+The full local workspace contains draft inputs such as:
+
+- raw notes and conversations
+- chapter draft folders
+- a longer book blueprint
+- material that may contain Thai/English mixed encoding issues
+- claims that still need source review and wording cleanup
+
+Those inputs are intentionally not published in this folder yet. Future public
+updates should promote only reviewed sections or small chapter drafts, with the
+source chain made clear.
+
+## Next Review Pass
+
+Before adding full chapters here, the next pass should:
+
+1. repair Thai/English encoding where needed
+2. separate raw notes from reviewed publishable draft
+3. mark which sections are economic history, policy proposal, or UET inference
+4. add source notes for historical and economic claims
+5. reduce any wording that sounds stronger than the evidence supports
+
+## Current Public Use
+
+This folder can be shared as a public project signal: it shows that the UET
+workspace includes an economics and wealth-origin book track, while keeping the
+unreviewed source material out of the public tree until it is safer and clearer
+to publish.

--- a/uet_history/PUBLIC_MANIFEST.md
+++ b/uet_history/PUBLIC_MANIFEST.md
@@ -1,4 +1,4 @@
-# UET History Public Manifest
+﻿# UET History Public Manifest
 
 **Updated:** 2026-07-08
 **Purpose:** Replace the old public `uet_history` tree with a curated structure
@@ -16,6 +16,7 @@ that reflects the current local workflow without publishing raw folders.
 | `uet_history/3_publish/README.md` | included | Publish-layer orientation. |
 | `uet_history/3_publish/books/README.md` | included | Book workspace orientation. |
 | `uet_history/3_publish/books/00_uet_core_theory/README.md` | included | Core UET theory book placeholder. |
+| `uet_history/3_publish/books/origin_of_wealth_and_economics/README.md` | included | Public concept outline for the economics and wealth-origin book track. |
 
 ## Excluded From This Public Update
 
@@ -25,7 +26,7 @@ that reflects the current local workflow without publishing raw folders.
 | `uet_history/_archive/` | Local archive and recovery material; not a current public source tree. |
 | `uet_history/Dev_history/` | Contains raw development snapshots, ZIPs, videos, and large historical assets. |
 | nested `1_raw/` folders inside `3_publish/` | Draft input material; not yet reviewed as public-safe. |
-| economics and wealth-origin book drafts | Local drafts exist, but need encoding, claim-strength, source-boundary, and raw/draft review before public promotion. |
+| full economics and wealth-origin book drafts | A public outline is included, but full local drafts still need encoding, claim-strength, source-boundary, and raw/draft review before promotion. |
 | media/audio/video/PDF/ZIP files | Large or potentially private assets; should be handled by a separate asset plan. |
 
 ## Legacy Paths Retired From Main


### PR DESCRIPTION
## Summary
- add a real public outline for origin_of_wealth_and_economics
- update the book workspace index so readers can see the economics/wealth-origin track
- update the public manifest and work ledger to keep raw/full drafts excluded until reviewed

## Scope control
This PR does not publish raw notes, chapter draft folders, PDFs, media, or the full local blueprint. It adds a shareable project-facing outline only.

## Test Plan
- git diff --cached --check before commit
- reviewed staged file list: 4 markdown files only
- kept claim wording at proposal/framework/outline level